### PR TITLE
NOJIRA - Update kramdown

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
     faraday-http-cache (2.0.0)
       faraday (~> 0.8)
     git (1.5.0)
-    kramdown (2.3.0)
+    kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
@@ -46,7 +46,7 @@ GEM
     open4 (1.3.4)
     public_suffix (4.0.3)
     rake (13.0.1)
-    rexml (3.2.4)
+    rexml (3.2.5)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)


### PR DESCRIPTION
## Ticket Reference
NOJIRA

## Description
This PR updates the kramdown gem due to a security vulnerability in previous versions:
https://nvd.nist.gov/vuln/detail/CVE-2021-28834